### PR TITLE
feat: Implement English/Spanish language switcher

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,3 +122,25 @@ footer .social-links a {
 footer .social-links a:hover {
     color: #b2fefa;
 }
+
+/* Language Switcher Styles */
+nav ul li button {
+    background-color: transparent;
+    color: white;
+    border: none;
+    padding: 0; /* Remove default button padding */
+    font-family: inherit; /* Inherit font from nav */
+    font-size: 18px; /* Match nav link font size */
+    cursor: pointer;
+    text-decoration: none; /* In case of any default button underlines */
+}
+
+nav ul li button:hover {
+    color: #b2fefa; /* Match nav link hover color */
+}
+
+/* Optional: Add a little spacing if needed, can be adjusted */
+nav ul li button#lang-en,
+nav ul li button#lang-es {
+    margin-left: 5px; /* Small space to the left of each button */
+}

--- a/index.html
+++ b/index.html
@@ -13,20 +13,22 @@
             <h1>JP Silva</h1>
         </div>
         <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="cv.pdf">CV</a></li>
-            <li><a href="githubppt">Presentations</a></li>
-            <li><a href="programming.html">Programming</a></li>
-            <li><a href="exercising.html">Exercising</a></li>
+            <li><a href="index.html"><span data-translate-key="nav_home">Home</span></a></li>
+            <li><a href="about.html"><span data-translate-key="nav_about">About</span></a></li>
+            <li><a href="cv.pdf"><span data-translate-key="nav_cv">CV</span></a></li>
+            <li><a href="githubppt"><span data-translate-key="nav_presentations">Presentations</span></a></li>
+            <li><a href="programming.html"><span data-translate-key="nav_programming">Programming</span></a></li>
+            <li><a href="exercising.html"><span data-translate-key="nav_exercising">Exercising</span></a></li>
+            <li><button id="lang-en">EN</button></li>
+            <li><button id="lang-es">ES</button></li>
         </ul>
     </nav>
 
     <!-- Hero Section -->
     <section class="hero">
-        <h1>Meet JP Silva</h1>
-        <p>A dedicated General Practitioner Physician with a passion for programming and fitness.</p>
-        <a href="cv.html" class="cta-button">View My CV</a>
+        <h1><span data-translate-key="hero_title">Meet JP Silva</span></h1>
+        <p><span data-translate-key="hero_subtitle">A dedicated General Practitioner Physician with a passion for programming and fitness.</span></p>
+        <a href="cv.html" class="cta-button"><span data-translate-key="hero_cta_button">View My CV</span></a>
     </section>
 
     <!-- Footer -->
@@ -35,7 +37,8 @@
             <a href="https://github.com/ertwro" target="_blank">GitHub</a>
             <!-- Add more social links as needed -->
         </div>
-        <p>© 2023 JP Silva. All rights reserved.</p>
+        <p><span data-translate-key="footer_copyright">© 2023 JP Silva. All rights reserved.</span></p>
     </footer>
+    <script src="js/translate.js" defer></script>
 </body>
 </html>

--- a/js/translate.js
+++ b/js/translate.js
@@ -1,0 +1,54 @@
+// 1. Translations Object
+// Placeholder Spanish translations. These will be updated in a later step.
+const translations = {
+  "nav_home": { "en": "Home", "es": "Inicio" },
+  "nav_about": { "en": "About", "es": "Acerca de" },
+  "nav_cv": { "en": "CV", "es": "CV" },
+  "nav_presentations": { "en": "Presentations", "es": "Presentaciones" },
+  "nav_programming": { "en": "Programming", "es": "Programación" },
+  "nav_exercising": { "en": "Exercising", "es": "Ejercicio" },
+  "hero_title": { "en": "Meet JP Silva", "es": "Conoce a JP Silva" },
+  "hero_subtitle": { "en": "A dedicated General Practitioner Physician with a passion for programming and fitness.", "es": "Un médico de cabecera dedicado con pasión por la programación y el fitness." },
+  "hero_cta_button": { "en": "View My CV", "es": "Ver Mi CV" },
+  "footer_copyright": { "en": "© 2023 JP Silva. All rights reserved.", "es": "© 2023 JP Silva. Todos los derechos reservados." }
+};
+
+// 2. setLanguage Function
+function setLanguage(lang) {
+  document.querySelectorAll('[data-translate-key]').forEach(element => {
+    const key = element.getAttribute('data-translate-key');
+    if (translations[key] && translations[key][lang]) {
+      element.textContent = translations[key][lang];
+    }
+  });
+  localStorage.setItem('language', lang);
+  // Optionally, update the lang attribute of the <html> tag
+  document.documentElement.lang = lang;
+}
+
+// 3. loadLanguage Function
+function loadLanguage() {
+  const savedLang = localStorage.getItem('language');
+  if (savedLang) {
+    setLanguage(savedLang);
+  } else {
+    setLanguage('en'); // Default to English
+  }
+}
+
+// 4. Event Listeners
+// Ensure the DOM is fully loaded before attaching event listeners
+document.addEventListener('DOMContentLoaded', () => {
+  const langEnButton = document.getElementById('lang-en');
+  const langEsButton = document.getElementById('lang-es');
+
+  if (langEnButton) {
+    langEnButton.addEventListener('click', () => setLanguage('en'));
+  }
+  if (langEsButton) {
+    langEsButton.addEventListener('click', () => setLanguage('es'));
+  }
+
+  // Load the saved language or default language when the page loads
+  loadLanguage();
+});


### PR DESCRIPTION
This commit introduces a language switching functionality to the index page, allowing you to toggle between English and Spanish content.

Key changes:
- Added language selection buttons (EN/ES) to the navigation bar in `index.html`.
- Modified `index.html` to use `data-translate-key` attributes on text elements for dynamic content updating.
- Created `js/translate.js` which contains:
    - A `translations` object storing English and Spanish strings.
    - A `setLanguage` function to update text content based on the selected language and store the preference in `localStorage`.
    - A `loadLanguage` function to apply the stored language preference on page load, defaulting to English.
    - Event listeners for the language buttons.
- Included `js/translate.js` in `index.html` using a deferred script tag.
- Populated `js/translate.js` with Spanish translations for all relevant text on the index page.
- Added CSS styles in `css/style.css` to ensure the language switcher buttons are visually consistent with existing navigation elements.

The implementation provides a seamless way for you to switch languages, with your preference remembered across sessions.